### PR TITLE
fix: queryTrackingBehavior in EfAsyncSession<>.WithTransaction

### DIFF
--- a/Light.DatabaseAccess.EntityFrameworkCore.Tests/PostgresUnitTests.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore.Tests/PostgresUnitTests.cs
@@ -1,0 +1,41 @@
+using System.Data;
+using System.Reflection;
+using FluentAssertions;
+using Light.DatabaseAccess.EntityFrameworkCore.Tests.DatabaseAccess;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Light.DatabaseAccess.EntityFrameworkCore.Tests;
+
+public sealed class PostgresUnitTests
+{
+    [Theory]
+    [InlineData(IsolationLevel.ReadCommitted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(IsolationLevel.Serializable, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(IsolationLevel.RepeatableRead, QueryTrackingBehavior.NoTracking)]
+    public void PassIsolationLevelAndQueryTrackingBehaviorToBaseClass(
+        IsolationLevel isolationLevel,
+        QueryTrackingBehavior queryTrackingBehavior
+    )
+    {
+        var dbContext = new MyDbContext(new DbContextOptionsBuilder<MyDbContext>().UseNpgsql().Options);
+
+        var session = new SomeSession(dbContext, isolationLevel, queryTrackingBehavior);
+
+        var sessionType = typeof(EfAsyncReadOnlySession<MyDbContext>.WithTransaction);
+        var actualLevel = (IsolationLevel) sessionType
+           .GetField("_isolationLevel", BindingFlags.Instance | BindingFlags.NonPublic)!
+           .GetValue(session)!;
+        actualLevel.Should().Be(isolationLevel);
+        dbContext.ChangeTracker.QueryTrackingBehavior.Should().Be(queryTrackingBehavior);
+    }
+
+    private sealed class SomeSession : EfAsyncSession<MyDbContext>.WithTransaction
+    {
+        public SomeSession(
+            MyDbContext dbContext,
+            IsolationLevel isolationLevel,
+            QueryTrackingBehavior queryTrackingBehavior = QueryTrackingBehavior.TrackAll
+        ) : base(dbContext, isolationLevel, queryTrackingBehavior) { }
+    }
+}

--- a/Light.DatabaseAccess.EntityFrameworkCore/EfAsyncSession.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore/EfAsyncSession.cs
@@ -82,7 +82,7 @@ public abstract class EfAsyncSession<TDbContext> : EfAsyncReadOnlySession<TDbCon
             IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
             QueryTrackingBehavior queryTrackingBehavior = QueryTrackingBehavior.TrackAll
         )
-            : base(dbContext, isolationLevel) { }
+            : base(dbContext, isolationLevel, queryTrackingBehavior) { }
 
         /// <summary>
         /// Saves the changes in the DB context and commits the transaction.

--- a/Light.DatabaseAccess.EntityFrameworkCore/Light.DatabaseAccess.EntityFrameworkCore.csproj
+++ b/Light.DatabaseAccess.EntityFrameworkCore/Light.DatabaseAccess.EntityFrameworkCore.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <Version>1.0.0</Version>
+        <Version>1.0.1</Version>
         <Authors>Kenny Pflug</Authors>
         <Company>Kenny Pflug</Company>
         <Copyright>Copyright © Kenny Pflug 2024</Copyright>
@@ -23,20 +23,17 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>readme.md</PackageReadmeFile>
         <PackageReleaseNotes>
-Light.DatabaseAccess.EntityFrameworkCore 1.0.0
+Light.DatabaseAccess.EntityFrameworkCore 1.0.1
 --------------------------------
             
-- initial release
-- use the EfAsyncReadOnlySession&lt;TDbContext&gt; and EfAsyncSession&lt;TDbContext&gt; base classes to easily implement database abstractions designed with Light.SharedCore
-- if you require dedicated transactions, derive your sessions from EfAsyncReadOnlySession&lt;TDbContext&gt;.WithTransaction or EfAsyncSession&lt;TDbContext&gt;.WithTransaction
-- these sessions automatically handle an appropritate QueryTrackingBehavior: as read-only sessions do not manipulate data, the use NoTrackingWithIdentityResolution by default        
+- fix: queryTrackingBehavior is now correctly forwarded in EfAsyncSession&lt;T&gt;.WithTransaction contructor        
 - read all the docs at https://github.com/feO2x/Light.DatabaseAccess.EntityFrameworkCore/
         </PackageReleaseNotes>
     </PropertyGroup>
     
     <ItemGroup>
         <PackageReference Include="Light.SharedCore" Version="2.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.6" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/readme.md
+++ b/readme.md
@@ -5,13 +5,13 @@
 ![Light Logo](light-logo.png)
 
 [![License](https://img.shields.io/badge/License-MIT-green.svg?style=for-the-badge)](https://github.com/feO2x/Light.DatabaseAccess.EntityFrameworkCore/blob/main/LICENSE)
-[![NuGet](https://img.shields.io/badge/NuGet-1.0.0-blue.svg?style=for-the-badge)](https://www.nuget.org/packages/Light.DatabaseAccess.EntityFrameworkCore/)
+[![NuGet](https://img.shields.io/badge/NuGet-1.0.1-blue.svg?style=for-the-badge)](https://www.nuget.org/packages/Light.DatabaseAccess.EntityFrameworkCore/)
 
 ## How to install
 
 Light.DatabaseAccess.EntityFrameworkCore is compiled against .NET 8 and available as a NuGet package. It can be installed via:
 
-- **Package Reference in csproj**: `<PackageReference Include="Light.DatabaseAccess.EntityFrameworkCore" Version="1.0.0" />`
+- **Package Reference in csproj**: `<PackageReference Include="Light.DatabaseAccess.EntityFrameworkCore" Version="1.0.1" />`
 - **dotnet CLI**: `dotnet add package Light.DatabaseAccess.EntityFrameworkCore`
 - **Visual Studio Package Manager Console**: `Install-Package Light.DatabaseAccess.EntityFrameworkCore`
 


### PR DESCRIPTION
fixes https://github.com/feO2x/Light.DatabaseAccess.EntityFrameworkCore/issues/4
The parameter is now forwarded to the base class.