### PR TITLE
Light.SharedCore v3.0.0 support

### DIFF
--- a/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/AddContact/EfAddContactSession.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/AddContact/EfAddContactSession.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Light.DatabaseAccess.EntityFrameworkCore.Tests.Contacts.AddContact;
 
-public sealed class EfAddContactSession : EfAsyncSession<MyDbContext>.WithTransaction, IAddContactSession
+public sealed class EfAddContactSession : EfSession<MyDbContext>.WithTransaction, IAddContactSession
 {
     public EfAddContactSession(MyDbContext dbContext) : base(dbContext, IsolationLevel.RepeatableRead) { }
     

--- a/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/AddContact/IAddContactSession.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/AddContact/IAddContactSession.cs
@@ -6,7 +6,7 @@ using Light.SharedCore.DatabaseAccessAbstractions;
 
 namespace Light.DatabaseAccess.EntityFrameworkCore.Tests.Contacts.AddContact;
 
-public interface IAddContactSession : IAsyncSession
+public interface IAddContactSession : ISession
 {
     Task<Contact?> GetContactAsync(Guid id, CancellationToken cancellationToken = default);
 

--- a/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/DeleteAllContacts/AdoNetDeleteAllContactsSession.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/DeleteAllContacts/AdoNetDeleteAllContactsSession.cs
@@ -6,7 +6,7 @@ using Npgsql;
 
 namespace Light.DatabaseAccess.EntityFrameworkCore.Tests.Contacts.DeleteAllContacts;
 
-public sealed class AdoNetDeleteAllContactsSession : EfAsyncSession<MyDbContext>.WithTransaction,
+public sealed class AdoNetDeleteAllContactsSession : EfSession<MyDbContext>.WithTransaction,
                                                      IDeleteAllContactsSession
 {
     public AdoNetDeleteAllContactsSession(MyDbContext dbContext) : base(dbContext, IsolationLevel.Serializable) { }

--- a/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/DeleteAllContacts/EfDeleteAllContactsSession.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/DeleteAllContacts/EfDeleteAllContactsSession.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Light.DatabaseAccess.EntityFrameworkCore.Tests.Contacts.DeleteAllContacts;
 
-public sealed class EfDeleteAllContactsSession : EfAsyncSession<MyDbContext>.WithTransaction, IDeleteAllContactsSession
+public sealed class EfDeleteAllContactsSession : EfSession<MyDbContext>.WithTransaction, IDeleteAllContactsSession
 {
     public EfDeleteAllContactsSession(MyDbContext dbContext) : base(dbContext, IsolationLevel.Serializable) { }
     

--- a/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/DeleteAllContacts/IDeleteAllContactsSession.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/DeleteAllContacts/IDeleteAllContactsSession.cs
@@ -4,7 +4,7 @@ using Light.SharedCore.DatabaseAccessAbstractions;
 
 namespace Light.DatabaseAccess.EntityFrameworkCore.Tests.Contacts.DeleteAllContacts;
 
-public interface IDeleteAllContactsSession : IAsyncSession
+public interface IDeleteAllContactsSession : ISession
 {
     Task DeleteAllContactsAsync(CancellationToken cancellationToken = default);
 }

--- a/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/GetAllContacts/AdoNetGetAllContactsSession.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/GetAllContacts/AdoNetGetAllContactsSession.cs
@@ -8,7 +8,7 @@ using Npgsql;
 
 namespace Light.DatabaseAccess.EntityFrameworkCore.Tests.Contacts.GetAllContacts;
 
-public sealed class AdoNetGetAllContactsSession : EfAsyncReadOnlySession<MyDbContext>, IGetAllContactsSession
+public sealed class AdoNetGetAllContactsSession : EfClient<MyDbContext>, IGetAllContactsSession
 {
     public AdoNetGetAllContactsSession(MyDbContext dbContext) : base(dbContext) { }
 

--- a/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/GetAllContacts/EfGetAllContactsReadUncommittedSession.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/GetAllContacts/EfGetAllContactsReadUncommittedSession.cs
@@ -7,7 +7,7 @@ using Light.DatabaseAccess.EntityFrameworkCore.Tests.DatabaseAccess.Model;
 
 namespace Light.DatabaseAccess.EntityFrameworkCore.Tests.Contacts.GetAllContacts;
 
-public sealed class EfGetAllContactsReadUncommittedSession : EfAsyncReadOnlySession<MyDbContext>.WithTransaction,
+public sealed class EfGetAllContactsReadUncommittedSession : EfClient<MyDbContext>.WithTransaction,
                                                              IGetAllContactsSession
 {
     public EfGetAllContactsReadUncommittedSession(MyDbContext dbContext) : base(

--- a/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/GetAllContacts/EfGetAllContactsSession.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/GetAllContacts/EfGetAllContactsSession.cs
@@ -6,7 +6,7 @@ using Light.DatabaseAccess.EntityFrameworkCore.Tests.DatabaseAccess.Model;
 
 namespace Light.DatabaseAccess.EntityFrameworkCore.Tests.Contacts.GetAllContacts;
 
-public sealed class EfGetAllContactsSession : EfAsyncReadOnlySession<MyDbContext>, IGetAllContactsSession
+public sealed class EfGetAllContactsSession : EfClient<MyDbContext>, IGetAllContactsSession
 {
     public EfGetAllContactsSession(MyDbContext dbContext) : base(dbContext) { }
 

--- a/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/GetAllContacts/IGetAllContactsSession.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/GetAllContacts/IGetAllContactsSession.cs
@@ -1,12 +1,12 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Light.DatabaseAccess.EntityFrameworkCore.Tests.DatabaseAccess.Model;
-using Light.SharedCore.DatabaseAccessAbstractions;
 
 namespace Light.DatabaseAccess.EntityFrameworkCore.Tests.Contacts.GetAllContacts;
 
-public interface IGetAllContactsSession : IAsyncReadOnlySession
+public interface IGetAllContactsSession : IAsyncDisposable
 {
     Task<List<Contact>> GetContactsAsync(CancellationToken cancellationToken = default);
 }

--- a/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/ManipulateContacts/EfManipulateContactsSession.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/ManipulateContacts/EfManipulateContactsSession.cs
@@ -6,7 +6,7 @@ using Light.DatabaseAccess.EntityFrameworkCore.Tests.DatabaseAccess.Model;
 
 namespace Light.DatabaseAccess.EntityFrameworkCore.Tests.Contacts.ManipulateContacts;
 
-public sealed class EfManipulateContactsSession : EfAsyncSession<MyDbContext>, IManipulateContactsSession
+public sealed class EfManipulateContactsSession : EfSession<MyDbContext>, IManipulateContactsSession
 {
     public EfManipulateContactsSession(MyDbContext dbContext) : base(dbContext) { }
     public Task<List<Contact>> GetContactsAsync(CancellationToken cancellationToken = default) =>

--- a/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/ManipulateContacts/IManipulateContactsSession.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore.Tests/Contacts/ManipulateContacts/IManipulateContactsSession.cs
@@ -4,7 +4,7 @@ using Light.SharedCore.DatabaseAccessAbstractions;
 
 namespace Light.DatabaseAccess.EntityFrameworkCore.Tests.Contacts.ManipulateContacts;
 
-public interface IManipulateContactsSession : IGetAllContactsSession, IAsyncSession
+public interface IManipulateContactsSession : IGetAllContactsSession, ISession
 {
     void RemoveContact(Contact contact);
 }

--- a/Light.DatabaseAccess.EntityFrameworkCore.Tests/DatabaseAccess/MyDbContext.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore.Tests/DatabaseAccess/MyDbContext.cs
@@ -3,10 +3,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Light.DatabaseAccess.EntityFrameworkCore.Tests.DatabaseAccess;
 
-public sealed class MyDbContext : DbContext
+public sealed class MyDbContext(DbContextOptions<MyDbContext> options) : DbContext(options)
 {
-    public MyDbContext(DbContextOptions<MyDbContext> options) : base(options) { }
-
     public DbSet<Contact> Contacts => Set<Contact>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/Light.DatabaseAccess.EntityFrameworkCore.Tests/Light.DatabaseAccess.EntityFrameworkCore.Tests.csproj
+++ b/Light.DatabaseAccess.EntityFrameworkCore.Tests/Light.DatabaseAccess.EntityFrameworkCore.Tests.csproj
@@ -9,14 +9,14 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Light.DatabaseAccess.EntityFrameworkCore\Light.DatabaseAccess.EntityFrameworkCore.csproj" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="xunit" Version="2.8.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+        <PackageReference Include="FluentAssertions" Version="[7.0.0]" />
         <PackageReference Include="Light.Xunit" Version="1.0.0" />
-        <PackageReference Include="Testcontainers.PostgreSql" Version="3.8.0" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="4.3.0" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4" />
     </ItemGroup>
 
 </Project>

--- a/Light.DatabaseAccess.EntityFrameworkCore.Tests/PostgresFixture.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore.Tests/PostgresFixture.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 using Light.DatabaseAccess.EntityFrameworkCore.Tests.Contacts;
 using Light.DatabaseAccess.EntityFrameworkCore.Tests.DatabaseAccess;
-using Light.DatabaseAccess.EntityFrameworkCore.Tests.DatabaseAccess.Model;
 using Microsoft.EntityFrameworkCore;
 using Testcontainers.PostgreSql;
 using Xunit;

--- a/Light.DatabaseAccess.EntityFrameworkCore/EfCoreExtensions.cs
+++ b/Light.DatabaseAccess.EntityFrameworkCore/EfCoreExtensions.cs
@@ -39,7 +39,7 @@ public static class EfCoreExtensions
         var dbConnection = dbContext.Database.GetDbConnection();
         
         return dbConnection.State == ConnectionState.Open ?
-            new ValueTask<TDbCommand>(CreateCommandAndTryAttachTransaction<TDbCommand>(dbContext, dbConnection, sql)) :
+            new (CreateCommandAndTryAttachTransaction<TDbCommand>(dbContext, dbConnection, sql)) :
             InitializeConnectionAndCreateCommandAsync<TDbCommand>(dbContext, sql, cancellationToken);
     }
     

--- a/Light.DatabaseAccess.EntityFrameworkCore/Light.DatabaseAccess.EntityFrameworkCore.csproj
+++ b/Light.DatabaseAccess.EntityFrameworkCore/Light.DatabaseAccess.EntityFrameworkCore.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <Version>1.1.0</Version>
+        <Version>3.0.0</Version>
         <Authors>Kenny Pflug</Authors>
         <Company>Kenny Pflug</Company>
         <Copyright>Copyright © Kenny Pflug 2024</Copyright>
@@ -23,11 +23,13 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>readme.md</PackageReadmeFile>
         <PackageReleaseNotes>
-Light.DatabaseAccess.EntityFrameworkCore 1.1.0
+Light.DatabaseAccess.EntityFrameworkCore 3.0.0
 --------------------------------
             
-- add DbContext property to .WithTransaction session base classes which allows synchronous access to the DbContext
-- add CreateCommandAsync to all session base classes, which allows you to easily create fully initialized DB commands 
+- support for Light.SharedCore 3.0.0
+- rename EfAsyncReadOnlySession&lt;TDbContext&gt; to EfClient&lt;TDbContext&gt;
+- rename EfAsyncSession&lt;TDbContext&gt; to EfSession&lt;TDbContext&gt;
+- v2.0.0 was skipped to align with Light.SharedCore versioning
 - read all the docs at https://github.com/feO2x/Light.DatabaseAccess.EntityFrameworkCore/
         </PackageReleaseNotes>
     </PropertyGroup>

--- a/Light.DatabaseAccess.EntityFrameworkCore/Light.DatabaseAccess.EntityFrameworkCore.csproj
+++ b/Light.DatabaseAccess.EntityFrameworkCore/Light.DatabaseAccess.EntityFrameworkCore.csproj
@@ -33,8 +33,8 @@ Light.DatabaseAccess.EntityFrameworkCore 1.1.0
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Light.SharedCore" Version="2.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.7" />
+        <PackageReference Include="Light.SharedCore" Version="3.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.3" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Rename `EfAsyncReadOnlySession<TDbContext>` to `EfClient<TDbContext>`
- Rename `EfAsyncSession<TDbContext>` to `EfSession<TDbContext>`
- update NuGet packages
- update readme and csproj for v3.0.0 release